### PR TITLE
pane show/hide icons reversed

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -76,7 +76,7 @@ namespace RegexTester {
             headerbar.title = _("Regex Tester");
             headerbar.show_close_button = true;
 
-            var show_sidebar = new Gtk.Button.from_icon_name ("pane-show-symbolic-rtl", Gtk.IconSize.LARGE_TOOLBAR);
+            var show_sidebar = new Gtk.Button.from_icon_name ("pane-hide-symbolic-rtl", Gtk.IconSize.LARGE_TOOLBAR);
             show_sidebar.clicked.connect (() => {
                 sidebar.visible = !sidebar.visible;
             });
@@ -128,10 +128,10 @@ namespace RegexTester {
             sidebar.width_request = 120;
             sidebar.notify["visible"].connect (() => {
                 if (sidebar.visible) {
-                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-hide-symbolic-rtl", Gtk.IconSize.LARGE_TOOLBAR);
+                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-show-symbolic-rtl", Gtk.IconSize.LARGE_TOOLBAR);
                     show_sidebar.tooltip_text = _("Hide Sidebar");
                 } else {
-                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-show-symbolic-rtl", Gtk.IconSize.LARGE_TOOLBAR);
+                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-hide-symbolic-rtl", Gtk.IconSize.LARGE_TOOLBAR);
                     show_sidebar.tooltip_text = _("Show Sidebar");
                 }
             });

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -76,7 +76,7 @@ namespace RegexTester {
             headerbar.title = _("Regex Tester");
             headerbar.show_close_button = true;
 
-            var show_sidebar = new Gtk.Button.from_icon_name ("pane-hide-symbolic-rtl", Gtk.IconSize.LARGE_TOOLBAR);
+            var show_sidebar = new Gtk.Button.from_icon_name ("pane-show-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
             show_sidebar.clicked.connect (() => {
                 sidebar.visible = !sidebar.visible;
             });
@@ -128,10 +128,10 @@ namespace RegexTester {
             sidebar.width_request = 120;
             sidebar.notify["visible"].connect (() => {
                 if (sidebar.visible) {
-                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-show-symbolic-rtl", Gtk.IconSize.LARGE_TOOLBAR);
+                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-hide-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
                     show_sidebar.tooltip_text = _("Hide Sidebar");
                 } else {
-                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-hide-symbolic-rtl", Gtk.IconSize.LARGE_TOOLBAR);
+                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-show-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
                     show_sidebar.tooltip_text = _("Show Sidebar");
                 }
             });


### PR DESCRIPTION
I think that `show_sidebar` button's purpose is more clear if we change the arrow direction.

**Show pane:**
![seleccion_270](https://user-images.githubusercontent.com/3936719/35186875-c2e3335a-fe1b-11e7-83e7-0edb583867dc.png)

**Hide pane:**
![seleccion_271](https://user-images.githubusercontent.com/3936719/35186876-c6aeae1a-fe1b-11e7-8eb6-a918a670f64e.png)

