### PR TITLE
Removed deprecated methods...Added support for global, ignore case, dot all flags...Fixes #20...Fixes #23

### DIFF
--- a/schemas/com.github.artemanufrij.regextester.gschema.xml
+++ b/schemas/com.github.artemanufrij.regextester.gschema.xml
@@ -1,5 +1,15 @@
 <schemalist>
   <schema path="/com/github/artemanufrij/regextester/" id="com.github.artemanufrij.regextester" gettext-domain="com.github.artemanufrij.regextester">
+    <key name="regex" type="s">
+      <default>""</default>
+      <summary>Regex</summary>
+      <description>Regex String</description>
+    </key>
+    <key name="text" type="s">
+      <default>""</default>
+      <summary>Text</summary>
+      <description>The text to match against Regex String</description>
+    </key>
     <key name="window-width" type="i">
       <default>720</default>
       <summary>The saved width of the window.</summary>

--- a/schemas/com.github.artemanufrij.regextester.gschema.xml
+++ b/schemas/com.github.artemanufrij.regextester.gschema.xml
@@ -1,39 +1,54 @@
 <schemalist>
-	<schema path="/com/github/artemanufrij/regextester/" id="com.github.artemanufrij.regextester" gettext-domain="com.github.artemanufrij.regextester">
-		<key name="window-width" type="i">
-			<default>720</default>
-			<summary>The saved width of the window.</summary>
-			<description>The saved width of the window.</description>
-		</key>
-		<key name="window-height" type="i">
-			<default>640</default>
-			<summary>The saved height of the window.</summary>
-			<description>The saved height of the window.</description>
-		</key>
-		<key name="window-x" type="i">
-			<default>-1</default>
-			<summary>The saved x-position of the window.</summary>
-			<description>The saved x-position of the window.</description>
-		</key>
-		<key name="window-y" type="i">
-			<default>-1</default>
-			<summary>The saved y-position of the window.</summary>
-			<description>The saved y-position of the window.</description>
-		</key>
-		<key name="sidebar-visible" type="b">
-		    <default>true</default>
-			<summary>Sidebar visibility.</summary>
-			<description>Sidebar visibility.</description>
-		</key>
-		<key name="multiline" type="b">
-		    <default>true</default>
-			<summary>Set Multiline flagSet Multiline flag.</summary>
-			<description>Set Multiline flagSet Multiline flag.</description>
-		</key>
-		<key name="regex-style" type="s">
-		    <default>"Perl"</default>
-			<summary>Regex Style.</summary>
-			<description>Regex Style.</description>
-		</key>
-	</schema>
+  <schema path="/com/github/artemanufrij/regextester/" id="com.github.artemanufrij.regextester" gettext-domain="com.github.artemanufrij.regextester">
+    <key name="window-width" type="i">
+      <default>720</default>
+      <summary>The saved width of the window.</summary>
+      <description>The saved width of the window.</description>
+    </key>
+    <key name="window-height" type="i">
+      <default>640</default>
+      <summary>The saved height of the window.</summary>
+      <description>The saved height of the window.</description>
+    </key>
+    <key name="window-x" type="i">
+      <default>-1</default>
+      <summary>The saved x-position of the window.</summary>
+      <description>The saved x-position of the window.</description>
+    </key>
+    <key name="window-y" type="i">
+      <default>-1</default>
+      <summary>The saved y-position of the window.</summary>
+      <description>The saved y-position of the window.</description>
+    </key>
+    <key name="sidebar-visible" type="b">
+      <default>true</default>
+      <summary>Sidebar visibility.</summary>
+      <description>Sidebar visibility.</description>
+    </key>
+    <key name="multiline" type="b">
+      <default>true</default>
+      <summary>Set Multiline flag.</summary>
+      <description>Set Multiline flag.</description>
+    </key>
+    <key name="ignore-case" type="b">
+      <default>true</default>
+      <summary>Set Ignore Case flag.</summary>
+      <description>Set Ignore Case flag.</description>
+    </key>
+    <key name="global" type="b">
+      <default>true</default>
+      <summary>Set Global flag.</summary>
+      <description>Set Global flag.</description>
+    </key>
+    <key name="dot-all" type="b">
+      <default>false</default>
+      <summary>Set Dot All flag.</summary>
+      <description>Set Dot All flag.</description>
+    </key>
+    <key name="regex-style" type="s">
+      <default>"Perl"</default>
+      <summary>Regex Style.</summary>
+      <description>Regex Style.</description>
+    </key>
+  </schema>
 </schemalist>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -42,7 +42,7 @@ namespace RegexTester {
         construct {
             var action_quit = new SimpleAction ("quit", null);
             add_action (action_quit);
-            string[] accel_quit = {"<Control>q", "0"};
+            string[] accel_quit = {"<Control>q"};
             set_accels_for_action ("app.quit", accel_quit);
             action_quit.activate.connect (
                 () => {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -26,9 +26,7 @@
  */
 
 namespace RegexTester {
-
     public class RegexTesterApp : Gtk.Application {
-
         static RegexTesterApp _instance = null;
 
         public static RegexTesterApp instance {
@@ -46,10 +44,10 @@ namespace RegexTester {
             set_accels_for_action ("app.quit", accel_quit);
             action_quit.activate.connect (
                 () => {
-                    if (mainwindow != null) {
-                        mainwindow.destroy ();
-                    }
-                });
+                if (mainwindow != null) {
+                    mainwindow.destroy ();
+                }
+            });
         }
 
         Gtk.Window mainwindow;
@@ -61,7 +59,7 @@ namespace RegexTester {
             }
 
             mainwindow = new MainWindow ();
-            mainwindow.set_application(this);
+            mainwindow.set_application (this);
         }
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -50,10 +50,6 @@ namespace RegexTester {
             settings = Settings.get_default ();
             load_window_settings ();
 
-            settings.changed.connect ((_) => {
-              load_window_settings();
-              load_other_settings();
-            });
             this.match.connect (
                 (count, group_items) => {
                     if (group_items.length () == 0) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -52,17 +52,17 @@ namespace RegexTester {
 
             this.match.connect (
                 (count, group_items) => {
-                    if (group_items.length () == 0) {
-                        return;
-                    }
-                    this.matches.add (new Widgets.MatchItem (count, group_items));
-                    this.matches.show_all ();
-                });
+                if (group_items.length () == 0) {
+                    return;
+                }
+                this.matches.add (new Widgets.MatchItem (count, group_items));
+                this.matches.show_all ();
+            });
             this.delete_event.connect (
                 () => {
-                    save_settings ();
-                    return false;
-                });
+                save_settings ();
+                return false;
+            });
             build_ui ();
         }
 
@@ -75,8 +75,8 @@ namespace RegexTester {
             var show_sidebar = new Gtk.Button.from_icon_name ("pane-show-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
             show_sidebar.clicked.connect (
                 () => {
-                    sidebar.visible = !sidebar.visible;
-                });
+                sidebar.visible = !sidebar.visible;
+            });
             headerbar.pack_end (show_sidebar);
             this.set_titlebar (headerbar);
 
@@ -112,13 +112,13 @@ namespace RegexTester {
             result.top_margin = result.left_margin = result.bottom_margin = result.right_margin = 12;
             result.wrap_mode = Gtk.WrapMode.WORD;
 
-            result.buffer.create_tag ("marked_first", "background", "#8cd5ff");
-            result.buffer.create_tag ("marked_second", "background", "#d1ff82");
-            result.buffer.create_tag ("marked_sub_0", "background", "#abacae");
-            result.buffer.create_tag ("marked_sub_1", "background", "#ff8c82");
-            result.buffer.create_tag ("marked_sub_2", "background", "#f9c440");
-            result.buffer.create_tag ("marked_sub_3", "background", "#95a3ab");
-            result.buffer.create_tag ("marked_sub_4", "background", "#e29ffc");
+            result.buffer.create_tag ("marked_first",     "background", "#8cd5ff");
+            result.buffer.create_tag ("marked_second",    "background", "#d1ff82");
+            result.buffer.create_tag ("marked_sub_0",     "background", "#abacae");
+            result.buffer.create_tag ("marked_sub_1",     "background", "#ff8c82");
+            result.buffer.create_tag ("marked_sub_2",     "background", "#f9c440");
+            result.buffer.create_tag ("marked_sub_3",     "background", "#95a3ab");
+            result.buffer.create_tag ("marked_sub_4",     "background", "#e29ffc");
             result.buffer.create_tag ("marked_highlight", "background", "#ffa154");
             result.buffer.changed.connect (check_regex);
 
@@ -132,14 +132,14 @@ namespace RegexTester {
             sidebar.width_request = 120;
             sidebar.notify["visible"].connect (
                 () => {
-                    if (sidebar.visible) {
-                        show_sidebar.image = new Gtk.Image.from_icon_name ("pane-hide-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-                        show_sidebar.tooltip_text = _ ("Hide Sidebar");
-                    } else {
-                        show_sidebar.image = new Gtk.Image.from_icon_name ("pane-show-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-                        show_sidebar.tooltip_text = _ ("Show Sidebar");
-                    }
-                });
+                if (sidebar.visible) {
+                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-hide-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                    show_sidebar.tooltip_text = _ ("Hide Sidebar");
+                } else {
+                    show_sidebar.image = new Gtk.Image.from_icon_name ("pane-show-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                    show_sidebar.tooltip_text = _ ("Show Sidebar");
+                }
+            });
 
             var options = new Gtk.Grid ();
             options.margin = 12;
@@ -193,7 +193,7 @@ namespace RegexTester {
 
             style_chooser = new Gtk.ComboBoxText ();
             style_chooser.append ("Javascript", "Javascript");
-            style_chooser.append ("Perl", "Perl");
+            style_chooser.append ("Perl",             "Perl");
             style_chooser.active_id = settings.regex_style;
             style_chooser.tooltip_text = _ ("Choose a Regex Style");
             style_chooser.changed.connect (check_regex);
@@ -215,11 +215,11 @@ namespace RegexTester {
             matches.expand = true;
             matches.selected_rows_changed.connect (
                 () => {
-                    var item = this.matches.get_selected_row () as Widgets.MatchItem;
-                    if (item != null) {
-                        this.set_selected_match (item.start, item.end);
-                    }
-                });
+                var item = this.matches.get_selected_row () as Widgets.MatchItem;
+                if (item != null) {
+                    this.set_selected_match (item.start, item.end);
+                }
+            });
             scroller.add (matches);
             sidebar.attach (scroller, 0, 4, 2, 1);
 
@@ -230,7 +230,7 @@ namespace RegexTester {
             this.show_all ();
 
             entry.grab_focus ();
-            load_other_settings();
+            load_other_settings ();
         }
 
         private void check_regex () {
@@ -241,104 +241,104 @@ namespace RegexTester {
             typing_timer = GLib.Timeout.add (
                 300,
                 () => {
-                    var regex = this.entry.text;
-                    entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, null);
+                var regex = this.entry.text;
+                entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, null);
 
-                    var buffer = result.buffer;
-                    var text = buffer.text;
+                var buffer = result.buffer;
+                var text = buffer.text;
 
-                    settings.text = text;
-                    settings.regex = regex;
+                settings.text = text;
+                settings.regex = regex;
 
-                    foreach (var child in matches.get_children ()) {
-                        matches.remove (child);
-                    }
+                foreach (var child in matches.get_children ()) {
+                    matches.remove (child);
+                }
 
-                    Gtk.TextIter s, e;
-                    buffer.get_bounds (out s, out e);
+                Gtk.TextIter s, e;
+                buffer.get_bounds (out s, out e);
 
-                    reset_tags (buffer);
+                reset_tags (buffer);
 
-                    if (regex == "") {
-                        typing_timer = 0;
-                        return false;
-                    }
-
-                    try {
-                        RegexCompileFlags flags = RegexCompileFlags.OPTIMIZE;
-
-                        if (multiline.active) {
-                            flags |= RegexCompileFlags.MULTILINE;
-                        }
-
-                        if (ignore_case.active) {
-                        	flags |= RegexCompileFlags.CASELESS;
-                        }
-
-                        if (!global.active) {
-                        	flags |= RegexCompileFlags.ANCHORED;
-                        }
-
-                        if (dot_all.active) {
-                        	flags |= RegexCompileFlags.DOTALL;
-                        }
-
-                        if (style_chooser.active_id == "Javascript") {
-                            flags |= RegexCompileFlags.JAVASCRIPT_COMPAT;
-                        }
-
-                        var reg = new Regex (regex, flags);
-                        MatchInfo mi;
-
-                        if (reg.match (text, 0, out mi)) {
-                            bool mod = true;
-                            int count = 1;
-
-                            int pos_start = 0;
-                            int pos_end = 0;
-                            do {
-                                GLib.List<RegexTester.GroupItem> group_items = new GLib.List<RegexTester.GroupItem> ();
-
-                                for (int i = 0; i < mi.get_match_count (); i++) {
-                                    mi.fetch_pos (i, out pos_start, out pos_end);
-                                    if (pos_start == pos_end) {
-                                        continue;
-                                    }
-
-                                    int offset_start = pos_start - shift_unichar (text, pos_start);
-                                    int offset_end = pos_end - shift_unichar (text, pos_end);
-
-                                    s.set_offset (offset_start);
-                                    e.set_offset (offset_end);
-
-                                    if (i == 0) {
-                                        if (mod) {
-                                            buffer.apply_tag_by_name ("marked_first", s, e);
-                                        } else {
-                                            buffer.apply_tag_by_name ("marked_second", s, e);
-                                        }
-                                        mod = !mod;
-                                    } else {
-                                        var sub_mod = "marked_sub_" + (i % 5).to_string ();
-                                        buffer.apply_tag_by_name (sub_mod, s, e);
-                                    }
-                                    string str = mi.fetch (i);
-
-                                    var new_group_item = new RegexTester.GroupItem (str, offset_start, offset_end);
-                                    group_items.append (new_group_item);
-                                }
-                                match (count, group_items);
-                                count++;
-                            } while (mi.next ());
-                        }
-                    } catch (Error e) {
-                        warning (e.message);
-                        entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-error");
-                        entry.set_icon_tooltip_text (Gtk.EntryIconPosition.SECONDARY, e.message);
-                    }
+                if (regex == "") {
                     typing_timer = 0;
                     return false;
-                });
+                }
+
+                try {
+                    RegexCompileFlags flags = RegexCompileFlags.OPTIMIZE;
+
+                    if (multiline.active) {
+                        flags |= RegexCompileFlags.MULTILINE;
+                    }
+
+                    if (ignore_case.active) {
+                        flags |= RegexCompileFlags.CASELESS;
+                    }
+
+                    if (!global.active) {
+                        flags |= RegexCompileFlags.ANCHORED;
+                    }
+
+                    if (dot_all.active) {
+                        flags |= RegexCompileFlags.DOTALL;
+                    }
+
+                    if (style_chooser.active_id == "Javascript") {
+                        flags |= RegexCompileFlags.JAVASCRIPT_COMPAT;
+                    }
+
+                    var reg = new Regex (regex, flags);
+                    MatchInfo mi;
+
+                    if (reg.match (text, 0, out mi)) {
+                        bool mod = true;
+                        int count = 1;
+
+                        int pos_start = 0;
+                        int pos_end = 0;
+                        do {
+                            GLib.List<RegexTester.GroupItem> group_items = new GLib.List<RegexTester.GroupItem> ();
+
+                            for (int i = 0; i < mi.get_match_count (); i++) {
+                                mi.fetch_pos (i, out pos_start, out pos_end);
+                                if (pos_start == pos_end) {
+                                    continue;
+                                }
+
+                                int offset_start = pos_start - shift_unichar (text, pos_start);
+                                int offset_end = pos_end - shift_unichar (text, pos_end);
+
+                                s.set_offset (offset_start);
+                                e.set_offset (offset_end);
+
+                                if (i == 0) {
+                                    if (mod) {
+                                        buffer.apply_tag_by_name ("marked_first", s, e);
+                                    } else {
+                                        buffer.apply_tag_by_name ("marked_second", s, e);
+                                    }
+                                    mod = !mod;
+                                } else {
+                                    var sub_mod = "marked_sub_" + (i % 5).to_string ();
+                                    buffer.apply_tag_by_name (sub_mod, s, e);
+                                }
+                                string str = mi.fetch (i);
+
+                                var new_group_item = new RegexTester.GroupItem (str, offset_start, offset_end);
+                                group_items.append (new_group_item);
+                            }
+                            match (count, group_items);
+                            count++;
+                        } while (mi.next ());
+                    }
+                } catch (Error e) {
+                    warning (e.message);
+                    entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-error");
+                    entry.set_icon_tooltip_text (Gtk.EntryIconPosition.SECONDARY, e.message);
+                }
+                typing_timer = 0;
+                return false;
+            });
         }
 
         private void set_selected_match (int start, int end) {
@@ -394,14 +394,14 @@ namespace RegexTester {
 
 
         private void load_other_settings () {
-        	this.sidebar.visible = settings.sidebar_visible;
-        	this.multiline.active = settings.multiline;
-        	this.ignore_case.active = settings.ignore_case;
-          this.global.active = settings.global;
-          this.dot_all.active = settings.dot_all;
-          this.style_chooser.active_id = settings.regex_style;
-          this.entry.text = settings.regex;
-          this.result.buffer.text = settings.text;
+            this.sidebar.visible = settings.sidebar_visible;
+            this.multiline.active = settings.multiline;
+            this.ignore_case.active = settings.ignore_case;
+            this.global.active = settings.global;
+            this.dot_all.active = settings.dot_all;
+            this.style_chooser.active_id = settings.regex_style;
+            this.entry.text = settings.regex;
+            this.result.buffer.text = settings.text;
         }
 
         private void save_settings () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -50,6 +50,10 @@ namespace RegexTester {
             settings = Settings.get_default ();
             load_window_settings ();
 
+            settings.changed.connect ((_) => {
+              load_window_settings();
+              load_other_settings();
+            });
             this.match.connect (
                 (count, group_items) => {
                     if (group_items.length () == 0) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -247,6 +247,9 @@ namespace RegexTester {
                     var buffer = result.buffer;
                     var text = buffer.text;
 
+                    settings.text = text;
+                    settings.regex = regex;
+
                     foreach (var child in matches.get_children ()) {
                         matches.remove (child);
                     }
@@ -396,7 +399,9 @@ namespace RegexTester {
         	this.ignore_case.active = settings.ignore_case;
           this.global.active = settings.global;
           this.dot_all.active = settings.dot_all;
-        	this.style_chooser.active_id = settings.regex_style;
+          this.style_chooser.active_id = settings.regex_style;
+          this.entry.text = settings.regex;
+          this.result.buffer.text = settings.text;
         }
 
         private void save_settings () {

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -40,6 +40,9 @@ namespace RegexTester {
         public int window_x { get; set; }
         public int window_y { get; set; }
         public bool multiline { get; set; }
+        public bool ignore_case { get; set; }
+        public bool global { get; set; }
+        public bool dot_all { get; set; }
         public bool sidebar_visible { get; set; }
         public string regex_style { get; set; }
 

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -27,7 +27,6 @@
 
 namespace RegexTester {
     public class Settings : Granite.Services.Settings {
-
         private static Settings settings;
         public static Settings get_default () {
             if (settings == null)

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -35,6 +35,8 @@ namespace RegexTester {
 
             return settings;
         }
+        public string regex { get; set; }
+        public string text { get; set; }
         public int window_width { get; set; }
         public int window_height { get; set; }
         public int window_x { get; set; }

--- a/src/Widgets/MatchItem.vala
+++ b/src/Widgets/MatchItem.vala
@@ -69,7 +69,7 @@ namespace RegexTester.Widgets {
                 var event_box = new Gtk.EventBox ();
                 event_box.button_press_event.connect ((sender, evt) => {
                     if (evt.type == Gdk.EventType.BUTTON_PRESS && evt.button == 3) {
-                        menu.popup (null, null, null, evt.button, evt.time);
+                        menu.popup_at_pointer (evt);
                         return true;
                     }
                     return false;

--- a/src/Widgets/MatchItem.vala
+++ b/src/Widgets/MatchItem.vala
@@ -27,7 +27,6 @@
 
 namespace RegexTester.Widgets {
     public class MatchItem : Gtk.ListBoxRow {
-
         public int start { get; set; }
         public int end { get; set; }
 
@@ -38,18 +37,17 @@ namespace RegexTester.Widgets {
             content.margin = 6;
             content.row_spacing = 6;
 
-            var match_count = new Gtk.Label (_("Match %d").printf (count));
+            var match_count = new Gtk.Label (_ ("Match %d").printf (count));
             match_count.hexpand = true;
             match_count.halign = Gtk.Align.START;
 
             var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
             int group_counter = 0;
             foreach (var item in group_items) {
-
                 var row = new Gtk.Grid ();
                 row.column_spacing = 4;
                 var menu = new Gtk.Menu ();
-                var menu_copy = new Gtk.MenuItem.with_label (_("Copy match…"));
+                var menu_copy = new Gtk.MenuItem.with_label (_ ("Copy match…"));
                 menu_copy.activate.connect (() => {
                     Gtk.Clipboard.get_default (Gdk.Display.get_default ()).set_text (item.text, -1);
                 });
@@ -59,7 +57,7 @@ namespace RegexTester.Widgets {
                 if (item == group_items.first ().data) {
                     match_text.label = "<b>%s</b>".printf (item.text);
                 } else {
-                    match_text.label = _("<small>Group %d:</small> %s").printf (group_counter, item.text);
+                    match_text.label = _ ("<small>Group %d:</small> %s").printf (group_counter, item.text);
                 }
                 match_text.tooltip_text = item.text;
                 match_text.ellipsize = Pango.EllipsizeMode.MIDDLE;
@@ -84,26 +82,25 @@ namespace RegexTester.Widgets {
                 menu.show_all ();
 
                 row.attach (event_box, 0, 0);
-                row.attach (pos, 1, 0);
+                row.attach (pos,       1, 0);
                 box.pack_start (row, true, true, 0);
 
-                group_counter ++;
+                group_counter++;
             }
 
             string pkgdir = "/usr/share/" + GLib.Environment.get_application_name ();
 
             Gtk.Image icon;
             if (count % 2 == 0) {
-                icon = new Gtk.Image.from_file(pkgdir + "/icons/regex-match-second.svg");
+                icon = new Gtk.Image.from_file (pkgdir + "/icons/regex-match-second.svg");
             } else {
-                icon = new Gtk.Image.from_file(pkgdir + "/icons/regex-match-first.svg");
+                icon = new Gtk.Image.from_file (pkgdir + "/icons/regex-match-first.svg");
             }
 
-            content.attach (icon, 0, 0);
+            content.attach (icon,        0, 0);
             content.attach (match_count, 1, 0);
-            content.attach (box, 0, 1, 2, 1);
+            content.attach (box,         0, 1, 2, 1);
             this.add (content);
         }
-
     }
 }


### PR DESCRIPTION
I discovered this app that you can use to test Regular Expressions and of course, I know there is RegexTester.com but I needed something that I can work offline.

The app supports basic things but they are not up to what I need and I dedicated time today to add all the features of RegexTester.com (except substitutions, I don't use it).

I also added other minor features like restoring the flags settings when you reopen the app, removed deprecated GTK methods etc.

I am already using my own build, hopefully, you will merge it so that others can enjoy the new features too.

**Before:**

![Screenshot from 2020-05-06 22-00-59](https://user-images.githubusercontent.com/22827908/81229101-32c1cb00-8fe7-11ea-9af4-d4bce1b29a24.png)

**After:**

![Screenshot from 2020-05-06 22-02-55](https://user-images.githubusercontent.com/22827908/81229116-38b7ac00-8fe7-11ea-978f-74f1c8880fe1.png)

**Restoring Regex Pattern and Text:**

![Kazam_screencast_00000 mp4](https://user-images.githubusercontent.com/22827908/81578823-41bbcb00-93a3-11ea-84da-508ce229d2b5.gif)

Fixes: #20 
Fixes: #23